### PR TITLE
Add `-bar` to definition of `:DetectIndent`.

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -187,5 +187,5 @@ fun! <SID>DetectIndent()
     endif
 endfun
 
-command! -nargs=0 DetectIndent call <SID>DetectIndent()
+command! -bar -nargs=0 DetectIndent call <SID>DetectIndent()
 


### PR DESCRIPTION
This will allow to use the bar (`|`) after the command, which comes in
handy in a custom mapping.
