### PR TITLE
Make the indentation guessing much less invasive.

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -9,13 +9,8 @@
 "
 " Usage:         :DetectIndent
 "
-"                " to prefer expandtab to noexpandtab when detection is
-"                " impossible:
+"                " to prefer expandtab to noexpandtab in ambiguous cases:
 "                :let g:detectindent_preferred_expandtab = 1
-"
-"                " to set a preferred indent level when detection is
-"                " impossible:
-"                :let g:detectindent_preferred_indent = 4
 "
 " Requirements:  Untested on Vim versions below 6.2
 
@@ -46,8 +41,8 @@ fun! <SID>IsCommentLine(line)
 endfun
 
 fun! <SID>DetectIndent()
-    let l:has_leading_tabs            = 0
-    let l:has_leading_spaces          = 0
+    let l:leading_tabs                = 0
+    let l:leading_spaces              = 0
     let l:shortest_leading_spaces_run = 0
     let l:shortest_leading_spaces_idx = 0
     let l:longest_leading_spaces_run  = 0
@@ -59,7 +54,7 @@ fun! <SID>DetectIndent()
     let verbose_msg = ''
     if ! exists("b:detectindent_cursettings")
       " remember initial values for comparison
-      let b:detectindent_cursettings = {'expandtab': &et, 'shiftwidth': &sw, 'tabstop': &ts, 'softtabstop': &sts}
+      let b:detectindent_cursettings = {'expandtab': &et, 'shiftwidth': &sw, 'softtabstop': &sts}
     endif
 
     let l:idx_end = line("$")
@@ -94,13 +89,13 @@ fun! <SID>DetectIndent()
         let l:leading_char = strpart(l:line, 0, 1)
 
         if l:leading_char == "\t"
-            let l:has_leading_tabs = 1
+            let l:leading_tabs = l:leading_tabs + 1
 
         elseif l:leading_char == " "
             " only interested if we don't have a run of spaces followed by a
             " tab.
             if -1 == match(l:line, '^ \+\t')
-                let l:has_leading_spaces = 1
+                let l:leading_spaces = l:leading_spaces + 1
                 let l:spaces = strlen(matchstr(l:line, '^ \+'))
                 if l:shortest_leading_spaces_run == 0 ||
                             \ l:spaces < l:shortest_leading_spaces_run
@@ -124,61 +119,28 @@ fun! <SID>DetectIndent()
 
     endwhile
 
-    if l:has_leading_tabs && ! l:has_leading_spaces
-        " tabs only, no spaces
-        let l:verbose_msg = "Detected tabs only and no spaces"
-        setl noexpandtab
-        if exists("g:detectindent_preferred_indent")
-            let &l:shiftwidth  = g:detectindent_preferred_indent
-            let &l:tabstop     = g:detectindent_preferred_indent
-        endif
+    if l:leading_spaces || l:leading_tabs
+        let l:verbose_msg = "Detected leading whitespace"
 
-    elseif l:has_leading_spaces && ! l:has_leading_tabs
-        " spaces only, no tabs
-        let l:verbose_msg = "Detected spaces only and no tabs"
-        setl expandtab
-        let &l:shiftwidth  = l:shortest_leading_spaces_run
-        let &l:softtabstop = l:shortest_leading_spaces_run
-
-    elseif l:has_leading_spaces && l:has_leading_tabs
-        " spaces and tabs
-        let l:verbose_msg = "Detected spaces and tabs"
-        setl noexpandtab
-        let &l:shiftwidth = l:shortest_leading_spaces_run
-
-        " mmmm, time to guess how big tabs are
-        if l:longest_leading_spaces_run <= 2
-            let &l:tabstop = 2
-        elseif l:longest_leading_spaces_run <= 4
-            let &l:tabstop = 4
+        if l:leading_tabs >= 3 * l:leading_spaces
+            setl noexpandtab
+        elseif l:leading_tabs >= 0.33 * l:leading_spaces &&
+                \ ! exists("g:detectindent_preferred_expandtab")
+            setl noexpandtab
         else
-            let &l:tabstop = 8
+            setl expandtab
+            let &l:shiftwidth  = l:shortest_leading_spaces_run
+            let &l:softtabstop = l:shortest_leading_spaces_run
         endif
 
     else
-        " no spaces, no tabs
         let l:verbose_msg = "Detected no spaces and no tabs"
-        if exists("g:detectindent_preferred_indent") &&
-                    \ exists("g:detectindent_preferred_expandtab")
-            setl expandtab
-            let &l:shiftwidth  = g:detectindent_preferred_indent
-            let &l:softtabstop = g:detectindent_preferred_indent
-        elseif exists("g:detectindent_preferred_indent")
-            setl noexpandtab
-            let &l:shiftwidth  = g:detectindent_preferred_indent
-            let &l:tabstop     = g:detectindent_preferred_indent
-        elseif exists("g:detectindent_preferred_expandtab")
-            setl expandtab
-        else
-            setl noexpandtab
-        endif
-
     endif
 
     if &verbose >= g:detectindent_verbosity
         echo l:verbose_msg
-                    \ ."; has_leading_tabs:" l:has_leading_tabs
-                    \ .", has_leading_spaces:" l:has_leading_spaces
+                    \ ."; leading_tabs:" l:leading_tabs
+                    \ .", leading_spaces:" l:leading_spaces
                     \ .", shortest_leading_spaces_run:" l:shortest_leading_spaces_run
                     \ .", shortest_leading_spaces_idx:" l:shortest_leading_spaces_idx
                     \ .", longest_leading_spaces_run:" l:longest_leading_spaces_run


### PR DESCRIPTION
In my experience this plugin gets the indentation wrong too often to be useful in its current state, and it adjusts different settings depending on what it finds. So I modified it to only ever adjust shiftwidth, softtabstop and of course expandtab, and only when it can make a reasonable guess about what's going on.

I'm not sure whether this is an appropriate pull request to actually be merged in upstream, because it does change behavior in some noticeable ways. In any case, here it is, and here's what I changed:
1.  Never set tabstop: just let the default from vimrc take priority.
   The only interesting case is when leading tabs and spaces are
   mixed, and in my experience the only sane guess in that situation
   is "4". This change removes the need for
   g:detectindent_preferred_indent
2.  Count how many times we see leading tabs vs. leading spaces, so
   that we can make a better guess about what the file is using.
   This change makes g:detectindent_preferred_expandtab just a
   hint as to which setting to lean towards when guessing.
3.  If we don't see any leading tabs or spaces, don't do anything.
   Users can set filetype defaults easily for this kind of
   situation anyways.
