### PR TITLE
Improve space-based shiftwidth detection

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -17,7 +17,12 @@
 "                " impossible:
 "                :let g:detectindent_preferred_indent = 4
 "
-" Requirements:  Untested on Vim versions below 6.2
+" Requirements:  Does not work on Vim versions below 7.0
+
+" Bail out if we're on an old version of vim
+if version < 700
+    finish
+endif
 
 if exists("loaded_detectindent")
     finish


### PR DESCRIPTION
I've modified your detectindent script slightly to change how the number of spaces per tab is detected. It seems to have improved the detection a little, and figured I'd let you know in case you wanted to incorporate any of my changes back into your tree.

Thanks!
