### PR TITLE
Ignore HTML/XML comment blocks

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -32,13 +32,17 @@ fun! <SID>HasCStyleComments()
     return index(["c", "cpp", "java", "javascript", "php"], &ft) != -1
 endfun
 
+fun! <SID>HasHTMLStyleComments()
+    return index(["html", "xml"], &ft) != -1
+endfun
+
 fun! <SID>IsCommentStart(line)
     " &comments aren't reliable
-    return <SID>HasCStyleComments() && a:line =~ '/\*'
+    return (<SID>HasCStyleComments() && a:line =~ '/\*') || (<SID>HasHTMLStyleComments() && a:line =~ '<!--')
 endfun
 
 fun! <SID>IsCommentEnd(line)
-    return <SID>HasCStyleComments() && a:line =~ '\*/'
+    return (<SID>HasCStyleComments() && a:line =~ '\*/') || (<SID>HasHTMLStyleComments() && a:line =~ '-->')
 endfun
 
 fun! <SID>IsCommentLine(line)


### PR DESCRIPTION
Hey Ciaran.

I made this change locally after experiencing the same problem as discussed in issue #12.

Obviously that thread is a year old and you made a strong argument against this change there, so I'm happy if you want to reject it. Just thought I should give you the opportunity to speak for yourself, rather than assuming rejection as a _fait accompli!_ :)
