### PR TITLE
Add vala to list of C style languages

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -29,7 +29,7 @@ if !exists('g:detectindent_verbosity')
 endif
 
 fun! <SID>HasCStyleComments()
-    return index(["c", "cpp", "java", "javascript", "php"], &ft) != -1
+    return index(["c", "cpp", "java", "javascript", "php", "vala"], &ft) != -1
 endfun
 
 fun! <SID>IsCommentStart(line)


### PR DESCRIPTION
A lot of Vala developers are coming directly from C, so they tend to use a similar comment syntax, one example which broke detectindent:
```
/*
 * Copyright (C) ...
[...]
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */

public class ValaPlugin : Object {
	Vala.CodeContext context;
[...]
```
It would be great to have this merged in.