### PR TITLE
Add option for preferred values with tabs + spaces

### DIFF
--- a/doc/detectindent.txt
+++ b/doc/detectindent.txt
@@ -30,6 +30,11 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 		:let g:detectindent_preferred_indent = 4
 <       in your |vimrc| file.
 
+	To use the preferred values when both tabs and spaces are detected,
+	set: >
+		:let g:detectindent_preferred_when_mixed = 1
+<	in your |vimrc| file.
+
 	To set limit for number of lines that will be analysed set: >
 		:let g:detectindent_max_lines_to_analyse = 1024
 <	in your |vimrc| file.
@@ -37,6 +42,8 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 ==============================================================================
 3. DetectIndent ChangeLog			      *detectindent-changelog*
 
+	v1.1 (20150225)
+	    * Add preferred_when_mixed.
 	v1.0 (20050105)
 	    * initial release after discussion on irc.freenode.net:#vim
 

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -16,6 +16,9 @@
 "                " to set a preferred indent level when detection is
 "                " impossible:
 "                :let g:detectindent_preferred_indent = 4
+"                
+"                " To use preferred values instead of guessing:
+"                :let g:detectindent_preferred_when_mixed = 1
 "
 " Requirements:  Untested on Vim versions below 6.2
 
@@ -140,7 +143,7 @@ fun! <SID>DetectIndent()
         let &l:shiftwidth  = l:shortest_leading_spaces_run
         let &l:softtabstop = l:shortest_leading_spaces_run
 
-    elseif l:has_leading_spaces && l:has_leading_tabs
+    elseif l:has_leading_spaces && l:has_leading_tabs && ! exists("g:detectindent_preferred_when_mixed")
         " spaces and tabs
         let l:verbose_msg = "Detected spaces and tabs"
         setl noexpandtab
@@ -157,7 +160,7 @@ fun! <SID>DetectIndent()
 
     else
         " no spaces, no tabs
-        let l:verbose_msg = "Detected no spaces and no tabs"
+        let l:verbose_msg = exists("g:detectindent_preferred_when_mixed") ? "preferred_when_mixed is active" : "Detected no spaces and no tabs"
         if exists("g:detectindent_preferred_indent") &&
                     \ exists("g:detectindent_preferred_expandtab")
             setl expandtab


### PR DESCRIPTION
Add detectindent_preferred_when_mixed so we use
detectindent_preferred_indent and detectindent_preferred_expandtab when
both tabs and spaces are found. This makes it easier for users to
enforce a "correct" setting when working in messy code.

I work in code where some of it is autogenerated with the wrong settings or people aren't careful with indentation, so this lets me force the preferred values (or leave the defaults if I don't set preferred values).
