### PR TITLE
Allow settings to be buffer-local

### DIFF
--- a/doc/detectindent.txt
+++ b/doc/detectindent.txt
@@ -28,7 +28,7 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 	To set a preferred value for 'shiftwidth' and 'tabstop' when they
 	cannot be automatically detected, set: >
 		:let g:detectindent_preferred_indent = 4
-<       in your |vimrc| file.
+<	in your |vimrc| file.
 
 	To use the preferred values when both tabs and spaces are detected,
 	set: >
@@ -39,11 +39,20 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 		:let g:detectindent_max_lines_to_analyse = 1024
 <	in your |vimrc| file.
 
+	To override |detectindent_preferred_expandtab| for specific filetypes
+	(example: use 4-character tabstops with tabs for python) set: >
+		:let b:detectindent_preferred_expandtab = 0
+	    	:let b:detectindent_preferred_indent = 4
+<	after/ftplugin/FILETYPENAMEHERE.vim (example:
+	after/ftplugin/python.vim). Using 0 acts as if the option was never
+	set.
+
 ==============================================================================
 3. DetectIndent ChangeLog			      *detectindent-changelog*
 
 	v1.1 (20150225)
 	    * Add preferred_when_mixed.
+	    * Add buffer-local options.
 	v1.0 (20050105)
 	    * initial release after discussion on irc.freenode.net:#vim
 

--- a/doc/detectindent.txt
+++ b/doc/detectindent.txt
@@ -30,6 +30,11 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 		:let g:detectindent_preferred_indent = 4
 <       in your |vimrc| file.
 
+	To use the preferred values when both tabs and spaces are detected,
+	set: >
+		:let g:detectindent_preferred_when_mixed = 1
+<	in your |vimrc| file.
+
 	To set limit for number of lines that will be analysed set: >
 		:let g:detectindent_max_lines_to_analyse = 1024
 <	in your |vimrc| file.
@@ -37,6 +42,8 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 ==============================================================================
 3. DetectIndent ChangeLog			      *detectindent-changelog*
 
+	v1.1 (20150225)
+	    * Add preferred_when_mixed.
 	v1.0 (20050105)
 	    * initial release after discussion on irc.freenode.net:#vim
 

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -16,6 +16,9 @@
 "                " to set a preferred indent level when detection is
 "                " impossible:
 "                :let g:detectindent_preferred_indent = 4
+"                
+"                " To use preferred values instead of guessing:
+"                :let g:detectindent_preferred_when_mixed = 1
 "
 " Requirements:  Untested on Vim versions below 6.2
 
@@ -140,7 +143,7 @@ fun! <SID>DetectIndent()
         let &l:shiftwidth  = l:shortest_leading_spaces_run
         let &l:softtabstop = l:shortest_leading_spaces_run
 
-    elseif l:has_leading_spaces && l:has_leading_tabs
+    elseif l:has_leading_spaces && l:has_leading_tabs && ! exists("g:detectindent_preferred_when_mixed")
         " spaces and tabs
         let l:verbose_msg = "Detected spaces and tabs"
         setl noexpandtab
@@ -157,7 +160,7 @@ fun! <SID>DetectIndent()
 
     else
         " no spaces, no tabs
-        let l:verbose_msg = "Detected no spaces and no tabs"
+        let l:verbose_msg = exists("g:detectindent_preferred_when_mixed") ? "preferred_when_mixed is active" : "Detected no spaces and no tabs"
         if exists("g:detectindent_preferred_indent") &&
                     \ exists("g:detectindent_preferred_expandtab")
             setl expandtab

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -48,6 +48,14 @@ fun! <SID>IsCommentLine(line)
     return <SID>HasCStyleComments() && a:line =~ '^\s\+//'
 endfun
 
+fun! s:GetValue(option)
+    if exists('b:'. a:option)
+        return get(b:, a:option)
+    else
+        return get(g:, a:option)
+    endif
+endfun
+
 fun! <SID>DetectIndent()
     let l:has_leading_tabs            = 0
     let l:has_leading_spaces          = 0
@@ -131,7 +139,7 @@ fun! <SID>DetectIndent()
         " tabs only, no spaces
         let l:verbose_msg = "Detected tabs only and no spaces"
         setl noexpandtab
-        if exists("g:detectindent_preferred_indent")
+        if s:GetValue("detectindent_preferred_indent")
             let &l:shiftwidth  = g:detectindent_preferred_indent
             let &l:tabstop     = g:detectindent_preferred_indent
         endif
@@ -143,7 +151,7 @@ fun! <SID>DetectIndent()
         let &l:shiftwidth  = l:shortest_leading_spaces_run
         let &l:softtabstop = l:shortest_leading_spaces_run
 
-    elseif l:has_leading_spaces && l:has_leading_tabs && ! exists("g:detectindent_preferred_when_mixed")
+    elseif l:has_leading_spaces && l:has_leading_tabs && ! s:GetValue("detectindent_preferred_when_mixed")
         " spaces and tabs
         let l:verbose_msg = "Detected spaces and tabs"
         setl noexpandtab
@@ -160,17 +168,17 @@ fun! <SID>DetectIndent()
 
     else
         " no spaces, no tabs
-        let l:verbose_msg = exists("g:detectindent_preferred_when_mixed") ? "preferred_when_mixed is active" : "Detected no spaces and no tabs"
-        if exists("g:detectindent_preferred_indent") &&
-                    \ exists("g:detectindent_preferred_expandtab")
+        let l:verbose_msg = s:GetValue("detectindent_preferred_when_mixed") ? "preferred_when_mixed is active" : "Detected no spaces and no tabs"
+        if s:GetValue("detectindent_preferred_indent") &&
+                    \ (s:GetValue("detectindent_preferred_expandtab"))
             setl expandtab
             let &l:shiftwidth  = g:detectindent_preferred_indent
             let &l:softtabstop = g:detectindent_preferred_indent
-        elseif exists("g:detectindent_preferred_indent")
+        elseif s:GetValue("detectindent_preferred_indent")
             setl noexpandtab
             let &l:shiftwidth  = g:detectindent_preferred_indent
             let &l:tabstop     = g:detectindent_preferred_indent
-        elseif exists("g:detectindent_preferred_expandtab")
+        elseif s:GetValue("detectindent_preferred_expandtab")
             setl expandtab
         else
             setl noexpandtab


### PR DESCRIPTION
This one is a bit more radical. I want python to use spaces and everything else to use tabs.

vimrc:

```
let g:detectindent_preferred_expandtab = 1
```

after/ftplugin/python.vim:

```
let b:detectindent_preferred_expandtab = 0
```

Only applies to indent settings (not max lines etc).

Add s:GetValue() to properly grab buffer-local options. Assumes if they
are active that we should use their value (instead of assuming existence
means 1) to allow us to force settings for specific filetypes.
