### PR TITLE
Consolidate applying indent settings

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -65,12 +65,11 @@ fun! s:SetIndent(expandtab, desired_tabstop)
         " what values of expandtab.
 
         let &l:tabstop = a:desired_tabstop
-        if v:version >= 704
-            " Zero automatically keeps in sync with tabstop in Vim 7.4+.
-            setl shiftwidth=0
-        else
-            let &l:shiftwidth = a:desired_tabstop
-        endif
+        " NOTE: shiftwidth=0 keeps it in sync with tabstop, but that breaks
+        " many indentation plugins that read 'sw' instead of calling the new
+        " shiftwidth(). See
+        " https://github.com/tpope/vim-sleuth/issues/25
+        let &l:shiftwidth = a:desired_tabstop
 
         if !a:expandtab
             if v:version >= 704

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -162,11 +162,13 @@ fun! <SID>DetectIndent()
     if l:has_leading_tabs && ! l:has_leading_spaces
         " tabs only, no spaces
         let l:verbose_msg = "Detected tabs only and no spaces"
-        if s:GetValue("detectindent_preferred_indent")
-            call s:SetIndent(0, g:detectindent_preferred_indent)
-        else
-            setl noexpandtab
+        let indent = s:GetValue("detectindent_preferred_indent")
+        if indent == 0
+            " Default behavior is to retain current tabstop. Still need to set
+            " it to ensure softtabstop, shiftwidth, tabstop are in sync.
+            let indent = &l:tabstop
         endif
+        call s:SetIndent(0, indent)
 
     elseif l:has_leading_spaces && ! l:has_leading_tabs
         " spaces only, no tabs

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -61,8 +61,8 @@ fun! s:SetIndent(expandtab, desired_tabstop)
 
     " Only modify tabs if we have a valid value.
     if a:desired_tabstop > 0
-        " See advice on `:help 'tabstop'` for logic of which values are set for
-        " what values of expandtab.
+        " See `:help 'tabstop'`. We generally adhere to #1 or #4, but when
+        " guessing what to do for mixed tabs and spaces we use #2.
 
         let &l:tabstop = a:desired_tabstop
         " NOTE: shiftwidth=0 keeps it in sync with tabstop, but that breaks
@@ -71,13 +71,11 @@ fun! s:SetIndent(expandtab, desired_tabstop)
         " https://github.com/tpope/vim-sleuth/issues/25
         let &l:shiftwidth = a:desired_tabstop
 
-        if !a:expandtab
-            if v:version >= 704
-                " Negative value automatically keeps in sync with shiftwidth in Vim 7.4+.
-                setl softtabstop=-1
-            else
-                let &l:softtabstop = a:desired_tabstop
-            endif
+        if v:version >= 704
+            " Negative value automatically keeps in sync with shiftwidth in Vim 7.4+.
+            setl softtabstop=-1
+        else
+            let &l:softtabstop = a:desired_tabstop
         endif
     endif
 endfun
@@ -178,7 +176,7 @@ fun! <SID>DetectIndent()
     elseif l:has_leading_spaces && l:has_leading_tabs && ! s:GetValue("detectindent_preferred_when_mixed")
         " spaces and tabs
         let l:verbose_msg = "Detected spaces and tabs"
-        call s:SetIndent(0, l:shortest_leading_spaces_run)
+        call s:SetIndent(1, l:shortest_leading_spaces_run)
 
         " mmmm, time to guess how big tabs are
         if l:longest_leading_spaces_run <= 2


### PR DESCRIPTION
Move applying indent settings into a single function to ensure we set them consistently.

Currently, there's some variance between which settings are applied. This ensures we always set values consistently. I'm trying to make us follow the guidelines in :help tabstop.

This PR changes behavior to set expandtab when we find both tabs and spaces. That case sets tabstop after calling SetIndent which is a bit weird, but presumably the guessing behavior is more useful than forcing tabstop=8.

Also, set softtabstop=-1 on supported versions of vim.
