### PR TITLE
Support JavaScript JSX syntax

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -32,7 +32,7 @@ if !exists('g:detectindent_verbosity')
 endif
 
 fun! <SID>HasCStyleComments()
-    return index(["c", "cpp", "java", "javascript", "php", "vala"], &ft) != -1
+    return index(["c", "cpp", "java", "javascript", "javascript.jsx", "php", "vala"], &ft) != -1
 endfun
 
 fun! <SID>IsCommentStart(line)


### PR DESCRIPTION
This patch makes sure tabs are correctly indented when using the [JSX](https://github.com/mxw/vim-jsx.git) plugin in JavaScript/JSX mode.
