### PR TITLE
Use buffer-values introduced in 3a33e22

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -140,8 +140,8 @@ fun! <SID>DetectIndent()
         let l:verbose_msg = "Detected tabs only and no spaces"
         setl noexpandtab
         if s:GetValue("detectindent_preferred_indent")
-            let &l:shiftwidth  = g:detectindent_preferred_indent
-            let &l:tabstop     = g:detectindent_preferred_indent
+            let &l:shiftwidth  = s:GetValue("detectindent_preferred_indent")
+            let &l:tabstop     = s:GetValue("detectindent_preferred_indent")
         endif
 
     elseif l:has_leading_spaces && ! l:has_leading_tabs
@@ -172,12 +172,12 @@ fun! <SID>DetectIndent()
         if s:GetValue("detectindent_preferred_indent") &&
                     \ (s:GetValue("detectindent_preferred_expandtab"))
             setl expandtab
-            let &l:shiftwidth  = g:detectindent_preferred_indent
-            let &l:softtabstop = g:detectindent_preferred_indent
+            let &l:shiftwidth  = s:GetValue("detectindent_preferred_indent")
+            let &l:tabstop     = s:GetValue("detectindent_preferred_indent")
         elseif s:GetValue("detectindent_preferred_indent")
             setl noexpandtab
-            let &l:shiftwidth  = g:detectindent_preferred_indent
-            let &l:tabstop     = g:detectindent_preferred_indent
+            let &l:shiftwidth  = s:GetValue("detectindent_preferred_indent")
+            let &l:tabstop     = s:GetValue("detectindent_preferred_indent")
         elseif s:GetValue("detectindent_preferred_expandtab")
             setl expandtab
         else


### PR DESCRIPTION
Buffer-local values were introduced and their existence was checked, however they were never actually used.

This PR fixes this. Now if you want linux sources (which typically only contain tabs to be displayed with 8 columns) to be automatically set to the right indentation level, while retaining personal preferences on other files, you can do:

```
autocmd BufRead /usr/src/linux* let b:detectindent_preferred_indent = 8
```
