### PR TITLE
Ignore multi-line comments in CSS

### DIFF
--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -32,7 +32,7 @@ if !exists('g:detectindent_verbosity')
 endif
 
 fun! <SID>HasCStyleComments()
-    return index(["c", "cpp", "java", "javascript", "php", "vala"], &ft) != -1
+    return index(["c", "cpp", "java", "javascript", "php", "vala", "css"], &ft) != -1
 endfun
 
 fun! <SID>IsCommentStart(line)


### PR DESCRIPTION
This PR adds CSS to the list of languages with C style syntax. Fixes Issue #14 
