### PR TITLE
Use 'comments' to ignore lines in block comments

### DIFF
--- a/doc/detectindent.txt
+++ b/doc/detectindent.txt
@@ -37,6 +37,12 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 
 	To set limit for number of lines that will be analysed set: >
 		:let g:detectindent_max_lines_to_analyse = 1024
+<	in your |vimrc| file. Low values will improve performance at the cost
+        of accuracy.
+
+        To ignore indent in comments by checking vim's syntax highlighting to
+        improve accuracy at a significant speed penalty: >
+                :let g:detectindent_check_comment_syntax = 1
 <	in your |vimrc| file.
 
 	To override |detectindent_preferred_expandtab| for specific filetypes

--- a/doc/detectindent.txt
+++ b/doc/detectindent.txt
@@ -45,6 +45,14 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
                 :let g:detectindent_check_comment_syntax = 1
 <	in your |vimrc| file.
 
+        DetectIndent uses vim's 'comments' variable to find and ignore
+        comments. To ignore this variable when detecting comments for a
+        filetype, you can add the filetype to this variable (example to ignore
+        in python files): >
+                :let g:detectindent_comments_blacklist = ['python']
+<        You'll probably want to enable |detectindent_check_comment_syntax| so
+        indentation in comments is ignored.
+
 	To override |detectindent_preferred_expandtab| for specific filetypes
 	(example: use 4-character tabstops with tabs for python) set: >
 		:let b:detectindent_preferred_expandtab = 0
@@ -56,6 +64,11 @@ Author:  Ciaran McCreesh <ciaran.mccreesh at googlemail.com>
 ==============================================================================
 3. DetectIndent ChangeLog			      *detectindent-changelog*
 
+        v1.3 (2020-01-02)
+            * Add 'comments' support.
+            * Turn off syntax detection for comments by default.
+        v1.2 (2017-08-29)
+            * Add syntax detection for comments.
 	v1.1 (20150225)
 	    * Add preferred_when_mixed.
 	    * Add buffer-local options.

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -65,12 +65,11 @@ fun! s:SetIndent(expandtab, desired_tabstop)
         " what values of expandtab.
 
         let &l:tabstop = a:desired_tabstop
-        if v:version >= 704
-            " Zero automatically keeps in sync with tabstop in Vim 7.4+.
-            setl shiftwidth=0
-        else
-            let &l:shiftwidth = a:desired_tabstop
-        endif
+        " NOTE: shiftwidth=0 keeps it in sync with tabstop, but that breaks
+        " many indentation plugins that read 'sw' instead of calling the new
+        " shiftwidth(). See
+        " https://github.com/tpope/vim-sleuth/issues/25
+        let &l:shiftwidth = a:desired_tabstop
 
         if !a:expandtab
             if v:version >= 704

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -162,11 +162,13 @@ fun! <SID>DetectIndent()
     if l:has_leading_tabs && ! l:has_leading_spaces
         " tabs only, no spaces
         let l:verbose_msg = "Detected tabs only and no spaces"
-        if s:GetValue("detectindent_preferred_indent")
-            call s:SetIndent(0, g:detectindent_preferred_indent)
-        else
-            setl noexpandtab
+        let indent = s:GetValue("detectindent_preferred_indent")
+        if indent == 0
+            " Default behavior is to retain current tabstop. Still need to set
+            " it to ensure softtabstop, shiftwidth, tabstop are in sync.
+            let indent = &l:tabstop
         endif
+        call s:SetIndent(0, indent)
 
     elseif l:has_leading_spaces && ! l:has_leading_tabs
         " spaces only, no tabs

--- a/plugin/detectindent.vim
+++ b/plugin/detectindent.vim
@@ -61,8 +61,8 @@ fun! s:SetIndent(expandtab, desired_tabstop)
 
     " Only modify tabs if we have a valid value.
     if a:desired_tabstop > 0
-        " See advice on `:help 'tabstop'` for logic of which values are set for
-        " what values of expandtab.
+        " See `:help 'tabstop'`. We generally adhere to #1 or #4, but when
+        " guessing what to do for mixed tabs and spaces we use #2.
 
         let &l:tabstop = a:desired_tabstop
         " NOTE: shiftwidth=0 keeps it in sync with tabstop, but that breaks
@@ -71,13 +71,11 @@ fun! s:SetIndent(expandtab, desired_tabstop)
         " https://github.com/tpope/vim-sleuth/issues/25
         let &l:shiftwidth = a:desired_tabstop
 
-        if !a:expandtab
-            if v:version >= 704
-                " Negative value automatically keeps in sync with shiftwidth in Vim 7.4+.
-                setl softtabstop=-1
-            else
-                let &l:softtabstop = a:desired_tabstop
-            endif
+        if v:version >= 704
+            " Negative value automatically keeps in sync with shiftwidth in Vim 7.4+.
+            setl softtabstop=-1
+        else
+            let &l:softtabstop = a:desired_tabstop
         endif
     endif
 endfun
@@ -178,7 +176,7 @@ fun! <SID>DetectIndent()
     elseif l:has_leading_spaces && l:has_leading_tabs && ! s:GetValue("detectindent_preferred_when_mixed")
         " spaces and tabs
         let l:verbose_msg = "Detected spaces and tabs"
-        call s:SetIndent(0, l:shortest_leading_spaces_run)
+        call s:SetIndent(1, l:shortest_leading_spaces_run)
 
         " mmmm, time to guess how big tabs are
         if l:longest_leading_spaces_run <= 2


### PR DESCRIPTION
You had a comment that `&comments aren't reliable`, so I'm not sure if you want this feature. If you are interested in merging, then let me know and I'll do the work to remove the syntax detecting code. (From #3, I can tell you don't want to use syntax.)

Builds on my PR #22. The last commit is the one I'm proposing here.